### PR TITLE
Fix contact parser

### DIFF
--- a/src/srdf/factories/contact.cc
+++ b/src/srdf/factories/contact.cc
@@ -74,10 +74,6 @@ namespace hpp {
 
         getChildOfType ("point", o);
         PointFactory* pts = o->as <PointFactory>();
-        getChildOfType ("triangle", o);
-        TriangleFactory* tri = o->as <TriangleFactory>();
-        getChildOfType ("shape", o);
-        ShapeFactory* shapes = o->as <ShapeFactory>();
 
         /// First build the sequence of points
         const PointFactory::OutType& v = pts->values();
@@ -86,34 +82,46 @@ namespace hpp {
         for (size_t i = 0; i < v.size (); i+=3)
           points.push_back (M.transform (fcl::Vec3f (v[i], v[i+1], v[i+2])));
 
-        /// Backward compatibility
-        /// Group points by 3 to form triangle
-        const TriangleFactory::OutType& indexes = tri->values();
-        if (indexes.size() % 3 != 0) throw std::length_error ("Triangle sequence size should be a multiple of 3.");
-        if (*std::max_element (indexes.begin (), indexes.end ()) >= points.size ())
-          throw std::out_of_range ("triangle should be a sequence of unsigned integer lower than the number of points.");
-        for (size_t i_tri = 0; i_tri < indexes.size (); i_tri+=3) {
-          /// For each of the point indexes
-          Shape_t t = boost::assign::list_of
-            (points [indexes [i_tri  ]])
-            (points [indexes [i_tri+1]])
-            (points [indexes [i_tri+2]]);
-          shapes_.push_back (JointAndShape_t (joint, t));
-        }
+        try {
+          /// Construct shapes
+          getChildOfType ("shape", o);
+          ShapeFactory* shapes = o->as <ShapeFactory>();
 
-        /// Construct shapes
-        const ShapeFactory::OutType& shapeIdxs = shapes->values();
-        if (indexes.size() % 3 != 0) throw std::length_error ("Triangle sequence size should be a multiple of 3.");
-        std::size_t i_shape = 0;
-        while (i_shape < shapeIdxs.size ()) {
-          if (i_shape + shapeIdxs[i_shape] > shapeIdxs.size ())
-            throw std::out_of_range ("shape should be a sequence of unsigned "
-                "integer: N iPoints_1 ... iPoints_N M iPoints_1 ... iPoints_M");
-          Shape_t shape (shapeIdxs [i_shape]);
-          for (size_t i = 1; i < shapeIdxs [i_shape] + 1; ++i)
-            shape[i] = points [shapeIdxs [i_shape + i]];
-          i_shape += shapeIdxs[i_shape] + 1;
-          shapes_.push_back (JointAndShape_t (joint, shape));
+          const ShapeFactory::OutType& shapeIdxs = shapes->values();
+          std::size_t i_shape = 0;
+          while (i_shape < shapeIdxs.size ()) {
+            if (i_shape + shapeIdxs[i_shape] > shapeIdxs.size ())
+              throw std::out_of_range ("shape should be a sequence of unsigned "
+                  "integer: N iPoints_1 ... iPoints_N M iPoints_1 ... iPoints_M");
+            Shape_t shape (shapeIdxs [i_shape]);
+            for (size_t i = 1; i < shapeIdxs [i_shape] + 1; ++i)
+              shape[i] = points [shapeIdxs [i_shape + i]];
+            i_shape += shapeIdxs[i_shape] + 1;
+            shapes_.push_back (JointAndShape_t (joint, shape));
+          }
+        } catch (const std::invalid_argument& e) {
+          /// Backward compatibility
+          try {
+            getChildOfType ("triangle", o);
+          } catch (const std::invalid_argument& eTri) {
+            throw std::invalid_argument (e);
+          }
+          TriangleFactory* tri = o->as <TriangleFactory>();
+          /// Group points by 3 to form triangle
+          const TriangleFactory::OutType& indexes = tri->values();
+          if (indexes.size() % 3 != 0) throw std::length_error ("Triangle sequence size should be a multiple of 3.");
+          if (*std::max_element (indexes.begin (), indexes.end ()) >= points.size ())
+            throw std::out_of_range ("triangle should be a sequence of unsigned integer lower than the number of points.");
+          for (size_t i_tri = 0; i_tri < indexes.size (); i_tri+=3) {
+            /// For each of the point indexes
+            Shape_t t = boost::assign::list_of
+              (points [indexes [i_tri  ]])
+              (points [indexes [i_tri+1]])
+              (points [indexes [i_tri+2]]);
+            shapes_.push_back (JointAndShape_t (joint, t));
+          }
+          hppDout (info, "Triangles are deprecated and will be removed."
+              " Use tag shape instead.");
         }
 
         device->add (root ()->prependPrefix (name ()), shapes_);


### PR DESCRIPTION
* Backward compatibility: tags triangle (deprecated) and shape are supported.