### PR TITLE
Overload hpp::manipulation::srdf::loadModelFromFile

### DIFF
--- a/include/hpp/manipulation/srdf/util.hh
+++ b/include/hpp/manipulation/srdf/util.hh
@@ -24,11 +24,29 @@ namespace hpp {
   namespace manipulation {
     namespace srdf {
       /// Reads the tags from SRDF as defined in \ref hpp_manipulation_urdf_srdf_syntax
+      /// \param robot robot to modify with the information stored in srdf file,
+      /// \param prefix prefix to insert before tags of the srdf file to get
+      ///        the corresponding object in the robot model
+      /// \param modelName part of the filename,
+      /// \param srdfSuffix part of the filename.
+      ///
+      /// The srdf file is retrieve by the following string:
+      /// "package://${package}/srdf/${modelName}${srdfSuffix}.srdf".
+      ///
       void loadModelFromFile (const DevicePtr_t& robot,
           const std::string& prefix,
           const std::string& package,
           const std::string& modelName,
           const std::string& srdfSuffix);
+
+      /// Reads the tags from SRDF as defined in \ref hpp_manipulation_urdf_srdf_syntax
+      /// \param prefix prefix to insert before tags of the srdf file to get
+      ///        the corresponding object in the robot model
+      /// \param srdfName name of the srdf file; may contain "package://" or
+      ///        "file://".
+      void loadModelFromFile (const DevicePtr_t& robot,
+          const std::string& prefix,
+          const std::string& srdfName);
 
       /// Reads the tags from SRDF as defined in \ref hpp_manipulation_urdf_srdf_syntax
       void loadModelFromXML (const DevicePtr_t& robot,

--- a/src/srdf/util.cc
+++ b/src/srdf/util.cc
@@ -33,13 +33,19 @@ namespace hpp {
           const std::string& modelName,
           const std::string& srdfSuffix)
       {
-        std::string srdfPath = "package://" + package + "/srdf/"
+        std::string srdfName = "package://" + package + "/srdf/"
           + modelName + srdfSuffix + ".srdf";
+        loadModelFromFile (robot, prefix, srdfName);
+      }
 
+      void loadModelFromFile (const DevicePtr_t& robot,
+          const std::string& prefix,
+          const std::string& srdfName)
+      {
         parser::Parser p;
 
         p.prefix(prefix);
-        p.parseFile (srdfPath, robot);
+        p.parseFile (srdfName, robot);
         hppDout (notice, "Finished parsing semantic informations.");
       }
 


### PR DESCRIPTION
  - new prototype takes as input full srdf filename. Requires https://github.com/humanoid-path-planner/hpp-corbaserver/pull/104.