### PR TITLE
remove std::unary_function

### DIFF
--- a/src/parser/factories/sequence.cc
+++ b/src/parser/factories/sequence.cc
@@ -40,7 +40,7 @@ namespace hpp {
 namespace manipulation {
 namespace parser {
 namespace {
-struct StringIsEmpty : public std::unary_function<std::string, bool> {
+struct StringIsEmpty {
   bool operator()(std::string s) const { return s.empty(); }
 };
 


### PR DESCRIPTION
std::unary_function is useless and was removed in C++17.