### PR TITLE
Use method shared_from_this before casting to weak pointer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,30 @@
         "type": "github"
       }
     },
+    "hpp-manipulation": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737531688,
+        "narHash": "sha256-04iogdE5WbDF1CfPiHaMlyBTbrXj2wu9DDNv8TaGweA=",
+        "owner": "florent-lamiraux",
+        "repo": "hpp-manipulation",
+        "rev": "986fadec01ce889605842b3a7f8c126302872bdf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "florent-lamiraux",
+        "ref": "devel",
+        "repo": "hpp-manipulation",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1734714690,
@@ -39,6 +63,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "hpp-manipulation": "hpp-manipulation",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,12 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+    # requires https://github.com/humanoid-path-planner/hpp-manipulation/pull/191
+    hpp-manipulation = {
+      url = "github:florent-lamiraux/hpp-manipulation/devel";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
   };
 
   outputs =
@@ -19,7 +25,7 @@
         "x86_64-darwin"
       ];
       perSystem =
-        { pkgs, self', ... }:
+        { pkgs, self', system, ... }:
         {
           devShells.default = pkgs.mkShell {
             inputsFrom = [ self'.packages.default ];
@@ -27,7 +33,9 @@
           };
           packages = {
             default = self'.packages.hpp-manipulation-urdf;
-            hpp-manipulation-urdf = pkgs.hpp-manipulation-urdf.overrideAttrs (_: {
+            hpp-manipulation-urdf = (pkgs.hpp-manipulation-urdf.override {
+              inherit (inputs.hpp-manipulation.packages.${system}) hpp-manipulation;
+            }).overrideAttrs (_: {
               # TODO: remove this after next release
               patches = [];
               src = pkgs.lib.fileset.toSource {

--- a/src/srdf/factories/gripper.cc
+++ b/src/srdf/factories/gripper.cc
@@ -103,7 +103,7 @@ void GripperFactory::finishTags() {
       gripperName, linkFrame.parentJoint, linkFrameId,
       linkFrame.placement * localPosition_, ::pinocchio::OP_FRAME));
   d->createData();
-  gripper_ = pinocchio::Gripper::create(gripperName, root()->device());
+  gripper_ = pinocchio::Gripper::create(gripperName, root()->device()->shared_from_this());
   gripper_->clearance(clearance);
   d->grippers.add(gripper_->name(), gripper_);
   hppDout(info, "Add gripper " << gripper_->name() << "\n\tattached to joint "

--- a/src/srdf/factories/gripper.cc
+++ b/src/srdf/factories/gripper.cc
@@ -103,7 +103,8 @@ void GripperFactory::finishTags() {
       gripperName, linkFrame.parentJoint, linkFrameId,
       linkFrame.placement * localPosition_, ::pinocchio::OP_FRAME));
   d->createData();
-  gripper_ = pinocchio::Gripper::create(gripperName, root()->device()->shared_from_this());
+  gripper_ = pinocchio::Gripper::create(gripperName,
+                                        root()->device()->shared_from_this());
   gripper_->clearance(clearance);
   d->grippers.add(gripper_->name(), gripper_);
   hppDout(info, "Add gripper " << gripper_->name() << "\n\tattached to joint "


### PR DESCRIPTION
  This modification fixes a bug in the way boost::python handles weak pointers.
  See https://stackoverflow.com/questions/8233252/boostpython-and-weak-ptr-stuff-disappearing
  for details.

Requires https://github.com/humanoid-path-planner/hpp-manipulation/pull/191.